### PR TITLE
build: remove bintray repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,7 @@
         <repository>
             <id>Vaadin prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
-        </repository>
-        <!-- The bintray repository contain webjars immediately after generation. If the webjar is available
-             in Maven central, you do not need this repository -->
-        <repository>
-            <id>webjars</id>
-            <url>https://dl.bintray.com/webjars/maven</url>
-        </repository>
+        </repository>        
         <repository>
 			<id>FlowingCode Releases</id>
 			<url>https://maven.flowingcode.com/releases</url>


### PR DESCRIPTION
Remove bintray.com/webjars repository, which is going to be shutdown.
The bintray repository contained webjars immediately after generation, while they were being published in Maven central.

See https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/