### PR TITLE
docs(readme): document allowed-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,14 @@ For a more comprehensive example, see com.flowingcode.vaadin.addons.carousel.Dem
     	Button first = new Button("|<");
     	first.addClickListener(e->cf.movePos(0));
 
+## Special configuration when using Spring
+
+By default, Vaadin Flow only includes `com/vaadin/flow/component` to be always scanned for UI components and views. For this reason, the add-on might need to be allowed in order to display correctly. 
+
+To do so, just add `com.flowingcode` to the `vaadin.allowed-packages` property (Vaadin 14-23: `vaadin.whitelisted-packages`) in `src/main/resources/application.properties`, like:
+
+```
+vaadin.allowed-packages = com.vaadin,org.vaadin,dev.hilla,com.flowingcode
+```
+
+More information on Spring scanning configuration [here](https://vaadin.com/docs/latest/integrations/spring/configuration/#configure-the-scanning-of-packages).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section that details special configuration instructions for Spring users. This guide explains how to adjust package scanning settings in your application properties to ensure proper display of UI components, and includes an example configuration and a reference link for more details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->