### PR TITLE
fix: handle null activeElement in _spaceCatcher AND fix: guard _moveManual and _ariaChecked against dom-repeat race AND MORE

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
+++ b/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
@@ -375,7 +375,9 @@ Polymer$0({
       for (var i = 0; i < dotElems.length; i++) {
         dotElems[i].setAttribute("aria-checked", "false");
       };
-      dotElems[this.position].setAttribute("aria-checked", "true");
+      if (this.position < dotElems.length) {
+        dotElems[this.position].setAttribute("aria-checked", "true");
+      }
     }
   },
 

--- a/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
+++ b/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
@@ -372,7 +372,7 @@ Polymer$0({
   _ariaChecked: function () {
     var dotElems = this.$.container.querySelectorAll('.slider__dot');
     if (dotElems.length > 0) {
-      for (var i = 0; i < this.totalSlides; i++) {
+      for (var i = 0; i < dotElems.length; i++) {
         dotElems[i].setAttribute("aria-checked", "false");
       };
       dotElems[this.position].setAttribute("aria-checked", "true");
@@ -478,13 +478,13 @@ Polymer$0({
   _moveManual: function () {
     var this$ = this;
     var dotElems = this.$.container.querySelectorAll('.slider__dot'), i;
-    for (i = 0; i < this.totalSlides; ++i) {
+    for (i = 0; i < dotElems.length; ++i) {
       dotElems[i].setAttribute("aria-label", "Slide " + parseInt(dotElems[i].getAttribute('aria-posinset')) + " selector");
       dotElems[i].addEventListener('click', function (e) {
         this$.movePos(e.target.getAttribute('aria-posinset') - 1);
       });
     };
-    if (this.totalSlides) {
+    if (dotElems.length) {
       this._dotStyles = window.getComputedStyle(dotElems[0]);
     }
   },

--- a/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
+++ b/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
@@ -480,10 +480,14 @@ Polymer$0({
     var dotElems = this.$.container.querySelectorAll('.slider__dot'), i;
     for (i = 0; i < dotElems.length; ++i) {
       dotElems[i].setAttribute("aria-label", "Slide " + parseInt(dotElems[i].getAttribute('aria-posinset')) + " selector");
-      dotElems[i].addEventListener('click', function (e) {
-        this$.movePos(e.target.getAttribute('aria-posinset') - 1);
-      });
     };
+    if (!this._dotClickListener) {
+      this._dotClickListener = function (e) {
+        const dot = e.target.closest('.slider__dot');
+        if (dot) this$.movePos(Number.parseInt(dot.getAttribute('aria-posinset'), 10) - 1);
+      };
+      this.$.container.addEventListener('click', this._dotClickListener);
+    }
     if (dotElems.length) {
       this._dotStyles = window.getComputedStyle(dotElems[0]);
     }
@@ -656,6 +660,10 @@ Polymer$0({
   detached: function() {
 	  this.autoProgress = false;
 	  removeListener(this.$.container, 'track', e => this._swipeHandler(e));
+	  if (this._dotClickListener) {
+	    this.$.container.removeEventListener('click', this._dotClickListener);
+	    this._dotClickListener = null;
+	  }
   },
   
   _increment: function(n) {

--- a/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
+++ b/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
@@ -540,14 +540,13 @@ Polymer$0({
   */
   _spaceCatcher: function (e) {
     e.preventDefault();
-    if (this.shadowRoot != null) {
-      var nextPos = this.shadowRoot.activeElement.getAttribute('aria-posinset');
+    const activeEl = this.shadowRoot && this.shadowRoot.activeElement;
+    if (activeEl) {
+      var nextPos = activeEl.getAttribute('aria-posinset');
+      if (nextPos) this.movePos(parseInt(nextPos) - 1);
     } else {
-      var nextPos = document.activeElement.getAttribute('aria-posinset');
+      this.movePos((this.position + 1) % this.totalSlides);
     }
-    if (!nextPos)
-      return;
-    this.movePos(parseInt(nextPos) - 1);
   },
 
   /**

--- a/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
+++ b/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
@@ -542,7 +542,7 @@ Polymer$0({
     e.preventDefault();
     const activeEl = this.shadowRoot && this.shadowRoot.activeElement;
     if (activeEl) {
-      var nextPos = activeEl.getAttribute('aria-posinset');
+      const nextPos = activeEl.getAttribute('aria-posinset');
       if (nextPos) this.movePos(parseInt(nextPos) - 1);
     } else {
       this.movePos((this.position + 1) % this.totalSlides);

--- a/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
+++ b/src/main/resources/META-INF/resources/frontend/paper-slider/l2t-paper-slider.js
@@ -543,7 +543,7 @@ Polymer$0({
     const activeEl = this.shadowRoot && this.shadowRoot.activeElement;
     if (activeEl) {
       const nextPos = activeEl.getAttribute('aria-posinset');
-      if (nextPos) this.movePos(parseInt(nextPos) - 1);
+      if (nextPos) this.movePos(Number.parseInt(nextPos, 10) - 1);
     } else {
       this.movePos((this.position + 1) % this.totalSlides);
     }


### PR DESCRIPTION
Close #49 
Close #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dot navigation now follows the actually rendered dots to prevent off-by-one and out-of-bounds navigation.
  * Click handling consolidated to a single delegated listener and cleaned up on detach to avoid duplicate handlers or leaks.
  * Dot-related styles are only initialized when dots exist.

* **Accessibility**
  * Dot controls expose accurate aria-checked states and per-dot aria-labels.
  * Keyboard/focus detection for advancing slides improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->