### PR TITLE
chore: link to FlowingCode javadoc site instead of javadoc.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
                             <doclint>none</doclint>
                             <failOnWarnings>true</failOnWarnings>
                             <links>
-                                <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
+                                <link>https://javadoc.flowingcode.com/artifact/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
                             </links>
                         </configuration>
                     </plugin>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->